### PR TITLE
Empty "Disallow:" directives should not mean "disallow all"

### DIFF
--- a/robotstxtparser.php
+++ b/robotstxtparser.php
@@ -254,9 +254,13 @@
 							if ($this->current_directive == self::DIRECTIVE_ALLOW
 								|| $this->current_directive == self::DIRECTIVE_DISALLOW
 							) {
-								$this->current_word = "/".ltrim($this->current_word, '/');
+								if (!empty($this->current_word)) {
+									$this->current_word = "/".ltrim($this->current_word, '/');
+								}
 							}
-							$this->rules[$this->userAgent][$this->current_directive][] = self::prepareRegexRule($this->current_word);
+							if (!empty($this->current_word)) {
+								$this->rules[$this->userAgent][$this->current_directive][] = self::prepareRegexRule($this->current_word);
+							}
 						}
 						$this->current_word = "";
 						$this->switchState(self::STATE_ZERO_POINT);

--- a/test/empty_disallow_test.php
+++ b/test/empty_disallow_test.php
@@ -1,0 +1,12 @@
+<?php
+require_once(__DIR__ . '/../robotstxtparser.php');
+$data = "
+User-Agent: *
+Disallow: 
+Disallow: /foo
+Disallow: /bar
+";
+$parser = new robotstxtparser($data, 'UTF-8');
+assert(!$parser->isDisallowed("/peanuts"));
+assert($parser->isDisallowed("/foo"));
+echo "OK\n";


### PR DESCRIPTION
A directive of the form:

<pre>Disallow:</pre>


means that all urls are allowed, not that they are all denied.

See the first entry here: http://en.wikipedia.org/wiki/Robots.txt#Examples
