### PR TITLE
Use the composer autoloader and clean up white space

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-   "name": "t1gor/robots-txt-parser",
-   "description": "Php class to parse robots.txt rules according to Google & Yandex specifications.",
-   "version": "0.0.1",
-   "keywords": ["robots.txt", "parser","Yandex", "Google"],
-   "homepage": "https://github.com/t1gor/Robots.txt-Parser-Class",
-   "type": "library",
-   "license": "MIT",
-   "minimum-stability": "dev",
-   "require-dev": {
+    "name": "t1gor/robots-txt-parser",
+    "description": "Php class to parse robots.txt rules according to Google & Yandex specifications.",
+    "version": "0.0.1",
+    "keywords": ["robots.txt", "parser", "Yandex", "Google"],
+    "homepage": "https://github.com/t1gor/Robots.txt-Parser-Class",
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "dev",
+    "require-dev": {
         "phpunit/phpunit": ">=3.7"
     },
     "authors": [
@@ -16,5 +16,8 @@
             "email": "igor.timoshenkov@gmail.com",
             "role": "lead"
         }
-    ]
+    ],
+    "autoload": {
+        "classmap": ["robotstxtparser.php"]
+    }
 }


### PR DESCRIPTION
By adding the class to the autoload class map, when people install via composer and require the vendor/autoload file - they don't need to also require the robots file. 

eg;

```
<?php
require 'vendor/autoload.php';
$parser = new RobotsTxtParser(file_get_contents('http://example.com/robots.txt'));
```

Which is handy if they have several other packages installed via composer, means we can just leverage that.

Also cleaned up some white space, had a mix of 3 and 4 space indentation.
