### PR TITLE
allow rules with uppercase characters

### DIFF
--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -197,7 +197,7 @@
 		 */
 		protected function shouldSwitchToZeroPoint()
 		{
-			return in_array($this->current_word, array(
+			return in_array(mb_strtolower($this->current_word), array(
 				self::DIRECTIVE_ALLOW,
 				self::DIRECTIVE_DISALLOW,
 				self::DIRECTIVE_HOST,
@@ -468,7 +468,7 @@
 		 */
 		protected function increment()
 		{
-			$this->current_char = mb_strtolower(mb_substr($this->content, $this->char_index, 1));
+			$this->current_char = mb_substr($this->content, $this->char_index, 1);
 			$this->current_word .= $this->current_char;
 			$this->current_word = trim($this->current_word);
 			$this->char_index++;

--- a/test/cases/DisallowUppercasePath.php
+++ b/test/cases/DisallowUppercasePath.php
@@ -1,0 +1,31 @@
+<?php
+class DisallowUppercasePathTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider generateDataForTest
+     * @covers RobotsTxtParser::isDisallowed
+     * @covers RobotsTxtParser::checkRule
+     * @param string $robotsTxtContent
+     */
+    public function testDisallowUppercasePath($robotsTxtContent)
+    {
+        // init parser
+        $parser = new RobotsTxtParser($robotsTxtContent);
+        $this->assertInstanceOf('RobotsTxtParser', $parser);
+        $this->assertTrue($parser->isDisallowed("/Admin"));
+    }
+
+    /**
+     * Generate test case data
+     * @return array
+     */
+    public function generateDataForTest()
+    {
+        return array(
+            array("
+					User-agent: *
+					Disallow : /Admin
+				")
+        );
+    }
+}


### PR DESCRIPTION
Before rules with uppercase characters would be changed to lowercase and as a result URLs that matched these rules would be ignored.  
I have included a test to demonstrate this, before the code changes were applied the test would fail.