### PR TITLE
Return from checkRule() in iteration only if rule passes

### DIFF
--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -549,7 +549,9 @@
 				$escaped = strtr($robotRule, array("@" => "\@"));
 
 				// return match result
-				return (bool) preg_match('@'.$escaped.'@', $value);
+				if (preg_match('@'.$escaped.'@', $value)) {
+					return true;
+				}
 			}
 
 			return $result;

--- a/test/cases/MoreRules.php
+++ b/test/cases/MoreRules.php
@@ -1,0 +1,48 @@
+<?php
+
+class MoreRules extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @link https://github.com/t1gor/Robots.txt-Parser-Class/issues/22
+	 */
+	public function testDisallowRules()
+	{
+		// init parser
+		$parser = new RobotsTxtParser("
+			User-Agent: *
+			Disallow: /foo
+			Disallow: /bar
+			Allow: /efg
+		");
+
+		// asserts
+		$this->assertTrue($parser->isDisallowed("/foo"));
+		$this->assertTrue($parser->isDisallowed("/bar"));
+		$this->assertFalse($parser->isDisallowed("/efg"));
+		$this->assertFalse($parser->isAllowed("/foo"));
+		$this->assertFalse($parser->isAllowed("/bar"));
+		$this->assertTrue($parser->isAllowed("/efg"));
+	}
+
+	/**
+	 * @link https://github.com/t1gor/Robots.txt-Parser-Class/issues/22
+	 */
+	public function testAllowRules()
+	{
+		// init parser
+		$parser = new RobotsTxtParser("
+			User-agent: *
+			Allow: /foo
+			Allow: /bar
+			Disallow: /efg
+		");
+
+		// asserts
+		$this->assertTrue($parser->isAllowed("/foo"));
+		$this->assertTrue($parser->isAllowed("/bar"));
+		$this->assertFalse($parser->isAllowed("/efg"));
+		$this->assertFalse($parser->isDisallowed("/foo"));
+		$this->assertFalse($parser->isDisallowed("/bar"));
+		$this->assertTrue($parser->isDisallowed("/efg"));
+	}
+}


### PR DESCRIPTION
This should fix reported problem and generally `isAllowed` and `isDisallowed` in general :).