### PR TITLE
User-agent case-insensitive

### DIFF
--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -306,7 +306,7 @@
             switch ($this->current_directive)
             {
                 case self::DIRECTIVE_USERAGENT:
-                    $this->setUserAgent($this->current_word);
+                    $this->setUserAgent(mb_strtolower($this->current_word));
                     break;
 
                 case self::DIRECTIVE_CRAWL_DELAY:
@@ -499,6 +499,7 @@
 		 */
 		public function isAllowed($url, $userAgent = "*")
 		{
+			if(isset($userAgent)) $userAgent = mb_strtolower($userAgent);
 			$this->checkEqualRules($url, $userAgent);
 			return $this->checkRule(self::DIRECTIVE_ALLOW, $url, $userAgent)
 				&& !$this->checkRule(self::DIRECTIVE_DISALLOW, $url, $userAgent);
@@ -514,6 +515,7 @@
 		 */
 		public function isDisallowed($url, $userAgent = "*")
 		{
+			if(isset($userAgent)) $userAgent = mb_strtolower($userAgent);
 			$this->checkEqualRules($url, $userAgent);
 			return $this->checkRule(self::DIRECTIVE_DISALLOW, $url, $userAgent);
 		}
@@ -529,6 +531,7 @@
 		 */
 		public function checkRule($rule, $value = '/', $userAgent = '*')
 		{
+			if(isset($userAgent)) $userAgent = mb_strtolower($userAgent);
 			$result = false;
 
 			// if rules are empty - allowed by default
@@ -573,6 +576,7 @@
          */
         public function getRules($userAgent = null)
         {
+            if(isset($userAgent)) $userAgent = mb_strtolower($userAgent);
             // return all rules
             if (is_null($userAgent)) {
                 return $this->rules;


### PR DESCRIPTION
According to specifications, group records are case-insensitive.
https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt#example-path-matches

This commit will also fix a bug causing one of the tests to fail in pull request #31, so make sure to merge this commit first, and then #31.
#31 is a bug-fix too. Making URL rules case-sensitive, according to specifications...