### PR TITLE
Fix rules ending with $.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "vipnytt/useragentparser": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=3.7",
+    "phpunit/phpunit": "~3.7",
     "codeclimate/php-test-reporter": ">=0.2"
   },
   "authors": [

--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -785,14 +785,8 @@ class RobotsTxtParser
         $escaped = strtr($rule, array('@' => '\@'));
         // match result
         if (preg_match('@' . $escaped . '@', $path)) {
-            if (strpos($escaped, '$') !== false) {
-                if (mb_strlen($escaped) - 1 == mb_strlen($path)) {
-                    return true;
-                }
-            } else {
-                $this->log[] = 'Rule match: Path';
-                return true;
-            }
+	        $this->log[] = 'Rule match: Path';
+	        return true;
         }
         return false;
     }
@@ -818,6 +812,10 @@ class RobotsTxtParser
         ) {
             $value .= '.*';
         }
+
+	    if (substr($value, 0, 2) != '.*') {
+		    $value = '^' . $value;
+	    }
         return $value;
     }
 


### PR DESCRIPTION
This is fix for issue #63.

Original check didn't considered rules containing `*`. So condition `if (mb_strlen($escaped) - 1 == mb_strlen($path)) {` tested exact length match between rule and path.

In pull request there is added start-of-string check for rules not beginning with `*` (see robots.txt specs https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values). Then string length condition mentioned above is no longer needed.

I have fixed Composer to ~3.7 because old rule >=3.7 resolved to Composer 7 which is not compatible with tests. Upgrading tests is not in scope of this issue.