### PR TITLE
Исправит ошибку проверки правила

### DIFF
--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -788,7 +788,7 @@ class RobotsTxtParser
      */
     protected function prepareRegexRule($value)
     {
-        $escape = ['$' => '\$', '?' => '\?', '.' => '\.', '*' => '.*'];
+        $escape = ['$' => '\$', '?' => '\?', '.' => '\.', '*' => '.*', '[' => '\[', ']' => '\]'];
         foreach ($escape as $search => $replace) {
             $value = str_replace($search, $replace, $value);
         }


### PR DESCRIPTION
Если в правиле присутствуют квадратные скобки, то возникает ошибка компиляции регулярки.
Например:
Правило: \*[]=\*
Итоговая регулярка: @.\*[]=.\*@
Ошибка: Compilation failed: missing terminating ] for character class at offset 7
Правильная регулярка: @.\*\\[\\]=.\*@