### PR TITLE
Fix new line determination

### DIFF
--- a/source/robotstxtparser.php
+++ b/source/robotstxtparser.php
@@ -222,7 +222,7 @@ class RobotsTxtParser
     protected function newLine()
     {
         return in_array(
-            PHP_EOL, array(
+            "\n", array(
                 $this->current_char,
                 $this->current_word
             )


### PR DESCRIPTION
PHP_EOL на винде состоит из двух символов: "\r\n", а директива считывается по одному символу ("\r" или "\n"). В итоге новая строка не определяется. Если же разбивать по "\n", то конец строки определяется корректно, а лишний символ "\r" удаляется затем trim'ом.