### PR TITLE
Adds a filter that guarantees to return batches ending with a line br…

### DIFF
--- a/source/Stream/Filters/EnsureEndOfLinesFilter.php
+++ b/source/Stream/Filters/EnsureEndOfLinesFilter.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace t1gor\RobotsTxtParser\Stream\Filters;
+
+use t1gor\RobotsTxtParser\Stream\CustomFilterInterface;
+
+class EnsureEndOfLinesFilter extends \php_user_filter implements CustomFilterInterface
+{
+    public const NAME = 'RTP_ensure_end_of_lines';
+
+    public $filtername = self::NAME;
+
+    protected string $incompleteLine = '';
+
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        $buffer = $this->incompleteLine;
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $buffer .= $bucket->data;
+        }
+        $consumed += mb_strlen($buffer);
+
+        $this->incompleteLine = '';
+        if (!$closing) {
+            // Есть как минимум один перенос строки
+            if (preg_match("/((?s)^.*[\n\r])(.*)$/mui", $buffer, $matches)) {
+                $buffer = $matches[1];                  // все строки с EOL
+                $this->incompleteLine = $matches[2];    // последняя строка без EOL
+            } else {
+                // Всего одна строка без EOL, ждём следующей порции
+                $this->incompleteLine = $buffer;
+                return \PSFS_FEED_ME;
+            }
+        }
+        $bucket = stream_bucket_new($this->stream, $buffer);
+        stream_bucket_append($out, $bucket);
+        return \PSFS_PASS_ON;
+    }
+}

--- a/source/Stream/GeneratorBasedReader.php
+++ b/source/Stream/GeneratorBasedReader.php
@@ -5,6 +5,7 @@ namespace t1gor\RobotsTxtParser\Stream;
 use Psr\Log\LogLevel;
 use t1gor\RobotsTxtParser\LogsIfAvailableTrait;
 use t1gor\RobotsTxtParser\RobotsTxtParser;
+use t1gor\RobotsTxtParser\Stream\Filters\EnsureEndOfLinesFilter;
 use t1gor\RobotsTxtParser\Stream\Filters\SkipDirectivesWithInvalidValuesFilter;
 use t1gor\RobotsTxtParser\Stream\Filters\SkipEndOfCommentedLineFilter;
 use t1gor\RobotsTxtParser\Stream\Filters\SkipCommentedLinesFilter;
@@ -27,6 +28,7 @@ class GeneratorBasedReader implements ReaderInterface {
 	protected function __construct() {
 		/** @note order matters */
 		$this->filters = [
+			EnsureEndOfLinesFilter::class                => false,
 			SkipCommentedLinesFilter::class              => false,
 			SkipEndOfCommentedLineFilter::class          => false,
 			TrimSpacesLeftFilter::class                  => false,


### PR DESCRIPTION
In case of very large `robots.txt` files (https://edu-medic.ru/robots.txt) standard batch size (4096 bytes) can lead to incorrect tree building. Because line can be divided at random position.

At the very beginning of filters chain new filter was added. It ensures, that all next filters will receive lines ending with EOL symbol.